### PR TITLE
Fix memory leak at inference time

### DIFF
--- a/mlreco/main_funcs.py
+++ b/mlreco/main_funcs.py
@@ -30,6 +30,8 @@ class Handlers:
         return list(self.__dict__.keys())
 
 
+# Use this function instead of itertools.cycle to avoid creating  a memory leak.
+# (itertools.cycle attempts to save all outputs in order to re-cycle through them)
 def cycle(data_io):
     while True:
         for x in data_io:

--- a/mlreco/main_funcs.py
+++ b/mlreco/main_funcs.py
@@ -9,7 +9,6 @@ import sys
 import numpy as np
 import torch
 import pprint
-import itertools
 from mlreco.trainval import trainval
 from mlreco.iotools.factories import loader_factory
 from mlreco.utils import utils
@@ -134,7 +133,7 @@ def prepare(cfg):
     handlers.data_io = loader_factory(cfg)
 
     # IO iterator
-    handlers.data_io_iter = itertools.cycle(handlers.data_io)
+    handlers.data_io_iter = iter(cycle(handlers.data_io))
 
     if 'trainval' in cfg:
         # Set random seed for reproducibility
@@ -144,11 +143,6 @@ def prepare(cfg):
         # Set primary device
         if len(cfg['trainval']['gpus']) > 0:
             torch.cuda.set_device(cfg['trainval']['gpus'][0])
-
-        # TODO check that it does what we want (cycle through dataloader)
-        # check on a small sample, check 1/ it cycles through and 2/ randomness
-        if cfg['trainval']['train']:
-            handlers.data_io_iter = iter(cycle(handlers.data_io))
 
         # Trainer configuration
         handlers.trainer = trainval(cfg)
@@ -178,10 +172,7 @@ def apply_event_filter(handlers,event_list=None):
     handlers.data_io = loader_factory(handlers.cfg,event_list)
 
     # IO iterator
-    handlers.data_io_iter = itertools.cycle(handlers.data_io)
-
-    if 'trainval' in handlers.cfg and handlers.cfg['trainval']['train']:
-        handlers.data_io_iter = iter(cycle(handlers.data_io))
+    handlers.data_io_iter = iter(cycle(handlers.data_io))
 
 
 def log(handlers, tstamp_iteration, #tspent_io, tspent_iteration,
@@ -327,7 +318,7 @@ def inference_loop(handlers):
         loaded_iteration = handlers.trainer.initialize()
         make_directories(handlers.cfg,loaded_iteration,handlers)
         handlers.iteration = 0
-        handlers.data_io_iter = itertools.cycle(handlers.data_io)
+        handlers.data_io_iter = iter(cycle(handlers.data_io))
         while handlers.iteration < handlers.cfg['trainval']['iterations']:
 
             epoch = handlers.iteration / float(len(handlers.data_io))


### PR DESCRIPTION
@kvtsang noticed that the CPU memory usage was increasing linearly with time/iterations at inference time, not at train time. For the record this is what he reported:
![image](https://user-images.githubusercontent.com/10686637/94750676-753fc780-033b-11eb-8059-f79a0ebfd181.png)

He also determined it happened with Icarus/Pdune data,  and old/new Singularity image containers. I then found that it was due to some legacy code cycling through the dataloader.

This does not cause a memory leak (and was being used at train time):
```
def cycle(data_io):
    while True:
        for x in data_io:
            yield x
handlers.data_io_iter = iter(cycle(handlers.data_io))
```
This serves a similar purpose (I think), and was the one used at inference time:
```
handlers.data_io_iter = itertools.cycle(handlers.data_io)
```
However it causes a memory leak (seems similar to the issue reported [here](https://github.com/pytorch/pytorch/issues/23900)).

Of course I do not remember *why* we had this distinction in place. Did we introduce it when we were trying to solve the CPU memory leak at train time, a long time ago, without noticing that this happened at inference time as well? Anyway, I cleaned up this legacy code and it should work better now.
