### PR TITLE
Fix concat_result related crash when initializing FullChainEvaluator in tutorials

### DIFF
--- a/mlreco/main_funcs.py
+++ b/mlreco/main_funcs.py
@@ -58,6 +58,10 @@ def process_config(cfg, verbose=True):
             cfg['trainval']['seed'] = int(cfg['trainval']['seed'])
         # Set MinkowskiEngine number of threads
         os.environ['OMP_NUM_THREADS'] = '16' # default value
+        # Set default concat_result
+        default_concat_result = ['input_edge_features', 'input_node_features','points', 'ppn_coords', 'mask_ppn', 'ppn_layers', 'classify_endpoints', 'seediness', 'margins', 'embeddings', 'fragments', 'fragments_seg', 'shower_fragments', 'shower_edge_index','shower_edge_pred','shower_node_pred','shower_group_pred','track_fragments', 'track_edge_index', 'track_node_pred', 'track_edge_pred', 'track_group_pred', 'particle_fragments', 'particle_edge_index', 'particle_node_pred', 'particle_edge_pred', 'particle_group_pred', 'particles','inter_edge_index', 'inter_node_pred', 'inter_edge_pred', 'inter_particles', 'node_pred_p', 'node_pred_type', 'flow_edge_pred', 'kinematics_particles', 'kinematics_edge_index', 'clust_fragments', 'clust_frag_seg', 'interactions', 'inter_cosmic_pred', 'node_pred_vtx', 'total_num_points', 'total_nonghost_points', 'spatial_embeddings', 'occupancy', 'hypergraph_features', 'features', 'feature_embeddings', 'covariance']
+        if 'concat_result' not in cfg['trainval']:
+            cfg['trainval']['concat_result'] = default_concat_result
 
     if 'iotool' in cfg:
 

--- a/mlreco/trainval.py
+++ b/mlreco/trainval.py
@@ -216,8 +216,7 @@ class trainval(object):
 
             # Here, contruct the unwrapped input and output
             # First, handle the case of a simple list concat
-            default_concat_result = ['input_edge_features', 'input_node_features','points', 'ppn_coords', 'mask_ppn', 'ppn_layers', 'classify_endpoints', 'seediness', 'margins', 'embeddings', 'fragments', 'fragments_seg', 'shower_fragments', 'shower_edge_index','shower_edge_pred','shower_node_pred','shower_group_pred','track_fragments', 'track_edge_index', 'track_node_pred', 'track_edge_pred', 'track_group_pred', 'particle_fragments', 'particle_edge_index', 'particle_node_pred', 'particle_edge_pred', 'particle_group_pred', 'particles','inter_edge_index', 'inter_node_pred', 'inter_edge_pred', 'inter_particles', 'node_pred_p', 'node_pred_type', 'flow_edge_pred', 'kinematics_particles', 'kinematics_edge_index', 'clust_fragments', 'clust_frag_seg', 'interactions', 'inter_cosmic_pred', 'node_pred_vtx', 'total_num_points', 'total_nonghost_points', 'spatial_embeddings', 'occupancy', 'hypergraph_features', 'features', 'feature_embeddings', 'covariance']
-            concat_keys = self._trainval_config.get('concat_result',default_concat_result)
+            concat_keys = self._trainval_config.get('concat_result', [])
             if len(concat_keys):
                 avoid_keys  = [k for k,v in input_data.items() if not k in concat_keys]
                 avoid_keys += [k for k,v in res.items()        if not k in concat_keys]


### PR DESCRIPTION
I did not realize that FullChainEvaluator was doomed to crash if `concat_result` was omitted from the config (the new normal moving forward). 

I changed the `process_config` function to set a default value to `concat_result`. Previously this was done in `trainval` as I thought it was the only place relying on `concat_result` (bad guess on my side).