### PR TITLE
Add parse_sparse3d_meta

### DIFF
--- a/mlreco/iotools/parsers.py
+++ b/mlreco/iotools/parsers.py
@@ -50,6 +50,22 @@ def parse_particle_singlep_einit(data):
     return -1
 
 
+def parse_sparse3d_meta(data):
+    event_tensor3d = data[0]
+    meta = event_tensor3d.meta()
+    return [
+        meta.min_x(),
+        meta.min_y(),
+        meta.min_z(),
+        meta.max_x(),
+        meta.max_y(),
+        meta.max_z(),
+        meta.size_voxel_x(),
+        meta.size_voxel_y(),
+        meta.size_voxel_z()
+    ]
+    
+
 def parse_sparse2d_meta(data):
     event_tensor2d = data[0]
     projection_id = 0  # default


### PR DESCRIPTION
`parse_sparse2d_meta` already existed. Added `parse_sparse3d_meta` which returns in order:

```python
    return [
        meta.min_x(),
        meta.min_y(),
        meta.min_z(),
        meta.max_x(),
        meta.max_y(),
        meta.max_z(),
        meta.size_voxel_x(),
        meta.size_voxel_y(),
        meta.size_voxel_z()
    ]
```

Can be used with an I/O config that looks like this:
```yaml
iotool:
  dataset:
    schema:
      meta:
        - parse_sparse3d_meta
        - sparse3d_reco
```
Then the meta information will be available in `data['meta'][entry]`.
