### PR TITLE
Remove eval mode from GraphSPICE

### DIFF
--- a/mlreco/models/graph_spice.py
+++ b/mlreco/models/graph_spice.py
@@ -275,13 +275,10 @@ class GraphSPICELoss(nn.Module):
         result['edge_index'] = [graph.edge_index]
         result['edge_truth'] = [graph.edge_truth]
 
-        if self.invert:
-            pred_labels = result['edge_score'][0] < 0.0
-        else:
-            pred_labels = result['edge_score'][0] >= 0.0
-
-        print("Pred Labels = ", pred_labels.sum(), pred_labels.shape)
-
+        # if self.invert:
+        #     pred_labels = result['edge_score'][0] < 0.0
+        # else:
+        #     pred_labels = result['edge_score'][0] >= 0.0
         # edge_diff = pred_labels != (result['edge_truth'][0] > 0.5)
 
         # print("Number of Wrong Edges = {} / {}".format(

--- a/mlreco/models/layers/cluster_cnn/losses/gs_embeddings.py
+++ b/mlreco/models/layers/cluster_cnn/losses/gs_embeddings.py
@@ -396,7 +396,7 @@ class NodeEdgeHybridLoss(torch.nn.modules.loss._Loss):
             edge_truth = torch.logical_not(edge_truth.long())
 
         iou = self.acc_fn(pred, edge_truth)
-        iou2 = self.acc_fn(~pred, ~edge_truth)
+        # iou2 = self.acc_fn(~pred, ~edge_truth)
 
         res['edge_accuracy'] = iou
         if 'loss' in res:

--- a/mlreco/models/layers/cluster_cnn/losses/gs_embeddings.py
+++ b/mlreco/models/layers/cluster_cnn/losses/gs_embeddings.py
@@ -44,6 +44,7 @@ class WeightedEdgeLoss(nn.Module):
         #     num_edges = y.shape[0]
         #     w = 1.0 / (1.0 - float(num_pos) / num_edges)
         #     weight[~y.bool()] = w
+        # print(logits.shape, logits.max())
         loss = self.loss_fn(logits, y.float(), weight=weight)
         return loss
 
@@ -372,7 +373,7 @@ class NodeEdgeHybridLoss(torch.nn.modules.loss._Loss):
         self.edge_loss_cfg = self.loss_config.get('edge_loss_cfg', {})
         self.invert = cfg.get('invert', True)
         self.edge_loss = WeightedEdgeLoss(invert=self.invert, **self.edge_loss_cfg)
-        self.is_eval = cfg['eval']
+        # self.is_eval = cfg['eval']
         self.acc_fn = IoUScore()
 
     def forward(self, result, segment_label, cluster_label):
@@ -383,23 +384,21 @@ class NodeEdgeHybridLoss(torch.nn.modules.loss._Loss):
         # print(result)
         edge_score = result['edge_score'][0].squeeze()
 
-        if not self.is_eval:
-            edge_truth = result['edge_truth'][0]
-            edge_loss = self.edge_loss(edge_score.squeeze(), edge_truth.float())
-            edge_loss = edge_loss.mean()
+        edge_truth = result['edge_truth'][0]
+        edge_loss = self.edge_loss(edge_score.squeeze(), edge_truth.float())
+        edge_loss = edge_loss.mean()
 
-            x = edge_score.squeeze()
-            y = edge_truth
+        x = edge_score.squeeze()
 
-            if self.invert:
-                pred = x < 0
-            else:
-                pred = x >= 0
+        pred = x >= 0
 
-            iou = self.acc_fn(pred, edge_truth)
-            res['edge_accuracy'] = iou
-        else:
-            edge_loss = 0
+        if self.invert:
+            edge_truth = torch.logical_not(edge_truth.long())
+
+        iou = self.acc_fn(pred, edge_truth)
+        iou2 = self.acc_fn(~pred, ~edge_truth)
+
+        res['edge_accuracy'] = iou
         if 'loss' in res:
             res['loss'] += edge_loss
         else:

--- a/mlreco/models/layers/cluster_cnn/losses/misc.py
+++ b/mlreco/models/layers/cluster_cnn/losses/misc.py
@@ -109,9 +109,9 @@ class IoUScore(torch.nn.Module):
     def forward(self, y_pred, y_true):
 
         iou = 0
-        intersection = (y_pred == 1) & (y_true == 1)
-        union = (y_pred == 1) | (y_true == 1)
-        if not union:
+        intersection = (y_pred.long() == 1) & (y_true.long() == 1)
+        union = (y_pred.long() == 1) | (y_true.long() == 1)
+        if not union.any():
             iou = 0
         else:
             iou = float(intersection.sum()) / float(union.sum())
@@ -142,7 +142,7 @@ class BinaryCELogDiceLoss(torch.nn.Module):
         denom = (p**2).sum() + (targets**2).sum()
         dice = torch.clamp((num + eps) / (denom + eps), min=eps, max=1-eps)
         dice_loss = -torch.log(dice)
-        # print("CE = {}, Dice = {}".format(bce, dice_loss))
+        # print("CE = {}, Dice = {} ({})".format(bce, dice_loss, dice))
         return self.w_ce * bce + self.w_dice * dice_loss
 
 

--- a/mlreco/utils/cluster/cluster_graph_constructor.py
+++ b/mlreco/utils/cluster/cluster_graph_constructor.py
@@ -245,10 +245,9 @@ class ClusterGraphConstructor:
                 graph_id += 1
                 self._info.append(graph_id_key)
 
-                if self.training:
-                    frag_labels = labels_batch[class_mask][:, self.cluster_col]
-                    truth = self.get_edge_truth(edge_indices, frag_labels)
-                    data.edge_truth = truth
+                frag_labels = labels_batch[class_mask][:, self.cluster_col]
+                truth = self.get_edge_truth(edge_indices, frag_labels)
+                data.edge_truth = truth
                 data_list.append(data)
             index += 1
 
@@ -311,11 +310,9 @@ class ClusterGraphConstructor:
                                     GraphID=graph_id)
                 graph_id += 1
                 self._info.append(graph_id_key)
-
-                if self.training:
-                    frag_labels = labels_batch[class_mask][:, self.cluster_col]
-                    truth = self.get_edge_truth(edge_indices, frag_labels)
-                    data.edge_truth = truth
+                frag_labels = labels_batch[class_mask][:, self.cluster_col]
+                truth = self.get_edge_truth(edge_indices, frag_labels)
+                data.edge_truth = truth
                 data_list.append(data)
             index += 1
 


### PR DESCRIPTION
This removes the train/eval split from GraphSPICE, so that it's possible to compute the edge loss and accuracy for both training and inference. 