### PR TITLE
Fix energy depositions units in analysis tools

### DIFF
--- a/analysis/algorithms/selections/stopping_muons.py
+++ b/analysis/algorithms/selections/stopping_muons.py
@@ -196,7 +196,11 @@ def stopping_muons(data_blob, res, data_idx, analysis_cfg, cfg):
             track_dict= update_dict
 
             # Split into segments and compute local dQ/dx
+            if end != 0: # Invert points along PCA
+                coords_pca = coords_pca.max() - coords_pca
+
             bins = np.arange(coords_pca.min(), coords_pca.max(), bin_size)
+            # bin_inds takes values in [1, len(bins)]
             bin_inds = np.digitize(coords_pca, bins)
 
             # spatial_bins = np.arange(0, spatial_size, spatial_bin_size)
@@ -215,7 +219,7 @@ def stopping_muons(data_blob, res, data_idx, analysis_cfg, cfg):
                     'cell_dN':  np.count_nonzero(mask),
                     'cell_dx': dx,
                     'cell_bin': i,
-                    'cell_residual_range': (i if end == 0 else len(bins)-i-1) * bin_size,
+                    'cell_residual_range': (i - 0.5) * bin_size,
                     'nbins': len(bins)
                 })
                 update_dict.update(track_dict)

--- a/analysis/classes/particle.py
+++ b/analysis/classes/particle.py
@@ -23,7 +23,7 @@ class Particle:
     size: int
         Total number of voxels that belong to this particle
     depositions: (N, 1) np.array
-        Array of energy deposition values for each voxel
+        Array of energy deposition values for each voxel (rescaled, ADC units)
     voxel_indices: (N, ) np.array
         Numeric integer indices of voxel positions of this particle
         with respect to the total array of point in a single image.
@@ -54,7 +54,7 @@ class Particle:
         self.id = group_id
         self.points = coords
         self.size = coords.shape[0]
-        self.depositions = depositions
+        self.depositions = depositions # In rescaled ADC
         self.voxel_indices = voxel_indices
         self.semantic_type = semantic_type
         self.pid = pid
@@ -125,7 +125,7 @@ class ParticleFragment(Particle):
         self.id = fragment_id
         self.points = coords
         self.size = coords.shape[0]
-        self.depositions = depositions
+        self.depositions = depositions # In rescaled ADC
         self.voxel_indices = voxel_indices
         self.semantic_type = semantic_type
         self.group_id = group_id
@@ -157,8 +157,9 @@ class ParticleFragment(Particle):
 
 class TruthParticleFragment(ParticleFragment):
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, depositions_MeV=None, **kwargs):
         super(TruthParticleFragment, self).__init__(*args, **kwargs)
+        self.depositions_MeV = depositions_MeV
 
     def __repr__(self):
         fmt = "TruthParticleFragment( Image ID={:<3} | Fragment ID={:<3} | Semantic_type: {:<15}"\
@@ -186,14 +187,23 @@ class TruthParticle(Particle):
         Raw larcv.Particle C++ object as retrived from parse_particles_asis.
     match: List[int]
         List of Particle IDs that match to this TruthParticle
+    coords_noghost:
+        Coordinates using true labels (not adapted to deghosting output)
+    depositions_noghost:
+        Depositions using true labels (not adapted to deghosting output), in MeV.
+    depositions_MeV:
+        Similar as `depositions`, i.e. using adapted true labels.
+        Using true MeV energy deposits instead of rescaled ADC units.
     '''
-    def __init__(self, *args, particle_asis=None, coords_noghost=None, depositions_noghost=None, **kwargs):
+    def __init__(self, *args, particle_asis=None, coords_noghost=None, depositions_noghost=None,
+                depositions_MeV=None, **kwargs):
         super(TruthParticle, self).__init__(*args, **kwargs)
         self.asis = particle_asis
         self.match = []
         self._match_counts = {}
         self.coords_noghost = coords_noghost
         self.depositions_noghost = depositions_noghost
+        self.depositions_MeV = depositions_MeV
 
     def __repr__(self):
         fmt = "TruthParticle( Image ID={:<3} | Particle ID={:<3} | Semantic_type: {:<15}"\


### PR DESCRIPTION
`depositions` should be in rescaled ADC (for `Particle`, `TruthParticle`, `ParticleFragment` and `TruthParticleFragment`).

New attribute `depositions_MeV` gives true charge in MeV for truth objects.