### PR TITLE
Allow empty edge index in GrapPA

### DIFF
--- a/analysis/classes/ui.py
+++ b/analysis/classes/ui.py
@@ -425,7 +425,7 @@ class FullChainPredictor:
 
         temp = []
 
-        if ('inter_group_pred' in self.result) and ('particles' in self.result):
+        if ('inter_group_pred' in self.result) and ('particles' in self.result) and len(fragments) > 0:
 
             group_labels = self._fit_predict_groups(entry)
             inter_labels = self._fit_predict_interaction_labels(entry)
@@ -561,7 +561,7 @@ class FullChainPredictor:
 
         assert node_pred_vtx.shape[0] == len(particles)
 
-        if ('inter_group_pred' in self.result) and ('particles' in self.result):
+        if ('inter_group_pred' in self.result) and ('particles' in self.result) and len(particles) > 0:
 
             assert len(self.result['inter_group_pred'][entry]) == len(particles)
             inter_labels = self._fit_predict_interaction_labels(entry)

--- a/mlreco/models/grappa.py
+++ b/mlreco/models/grappa.py
@@ -305,7 +305,7 @@ class GNN(torch.nn.Module):
 
         # Form the requested network
         if len(clusts) == 1:
-            edge_index = np.empty((2,0))
+            edge_index = np.empty((2,0), dtype=np.int64)
         elif self.network == 'complete':
             edge_index = complete_graph(batch_ids, dist_mat, self.edge_max_dist)
         elif self.network == 'delaunay':
@@ -329,9 +329,6 @@ class GNN(torch.nn.Module):
             edge_index = edge_index[:,mask]
 
         # Update result with a list of edges for each batch id
-        if not edge_index.shape[1]:
-            return {**result, 'edge_index':[np.empty((2,0)) for _ in batches]}
-
         edge_index_split, ebids = split_edge_index(edge_index, batch_ids, batches)
         result['edge_index'] = [edge_index_split]
 

--- a/mlreco/utils/cluster/cluster_graph_constructor.py
+++ b/mlreco/utils/cluster/cluster_graph_constructor.py
@@ -345,10 +345,13 @@ class ClusterGraphConstructor:
             raise ValueError('Edge attributes are already set: {}'\
                 .format(self._graph_batch.edge_attr))
         else:
-            edge_attr = kernel_fn(
-                self._graph_batch.x[self._graph_batch.edge_index[0, :]],
-                self._graph_batch.x[self._graph_batch.edge_index[1, :]])
-            w = edge_attr.squeeze()
+            if self._graph_batch.edge_index.shape[1] > 0:
+                edge_attr = kernel_fn(
+                    self._graph_batch.x[self._graph_batch.edge_index[0, :]],
+                    self._graph_batch.x[self._graph_batch.edge_index[1, :]])
+                w = edge_attr.squeeze()
+            else:
+                w = torch.empty((0,), device=self._graph_batch.edge_index.device)
             self._graph_batch.edge_attr = w
             self._graph_batch.add_edge_features(w, 'edge_attr')
 

--- a/mlreco/utils/cluster/fragmenter.py
+++ b/mlreco/utils/cluster/fragmenter.py
@@ -222,9 +222,13 @@ class GraphSPICEFragmentManager(FragmentManager):
         #     print(torch.unique(filtered_input[f, self._batch_column], return_counts=True))
 
         #print(torch.unique(filtered_input[:, self._batch_column]))
-        frag_batch_ids = get_cluster_batch(filtered_input.detach().cpu().numpy(), \
-                                        fragments, batch_index=self._batch_column)
-        fragments_seg = get_cluster_label(filtered_input, fragments, column=4)
+        if len(fragments) > 0:
+            frag_batch_ids = get_cluster_batch(filtered_input.detach().cpu().numpy(), \
+                                            fragments, batch_index=self._batch_column)
+            fragments_seg = get_cluster_label(filtered_input, fragments, column=4)
+        else:
+            frag_batch_ids = np.empty((0,))
+            fragments_seg = np.empty((0,))
         # fragments = [np.arange(filtered_input.shape[0])[clust] \
         #              for clust in fragments]
         # We want the indices to refer to the unfiltered, original input

--- a/mlreco/utils/gnn/data.py
+++ b/mlreco/utils/gnn/data.py
@@ -302,6 +302,10 @@ def split_edge_index(edge_index: nb.int64[:,:],
         [np.ndarray]: (B) List of list of edges
         [np.ndarray]: (B) List of edge IDs in each batch
     """
+    # If the input is empty, simply return defaults
+    if not edge_index.shape[1]:
+        return [np.empty((2,0), dtype=np.int64) for b in batches], [np.empty(0, dtype=np.int64) for b in batches]
+
     # For each batch ID, get the list of edges that belong to it
     ebids = [np.where(batch_ids[edge_index[0]] == b)[0] for b in batches]
 

--- a/mlreco/utils/unwrap.py
+++ b/mlreco/utils/unwrap.py
@@ -130,7 +130,8 @@ def unwrap_scn(data_blob, outputs, batch_id_col, avoid_keys, input_key='input_da
                 batch_map = {}
                 batch_id_loc = batch_id_col if d.shape[1] > batch_id_col else -1
                 batch_idx = np.unique(d[:,batch_id_loc])
-                batch_idx_max = max(batch_idx_max, int(batch_idx.max()))
+                if len(batch_idx):
+                    batch_idx_max = max(batch_idx_max, int(batch_idx.max()))
                 for b in batch_idx:
                     batch_map[b] = d[:,batch_id_loc] == b
                 unwrap_map[d.shape[0]]=batch_map
@@ -209,7 +210,8 @@ def unwrap_scn(data_blob, outputs, batch_id_col, avoid_keys, input_key='input_da
                 #     assert False
                 # print(target, len(batch_idx), len(np.unique(batch_idx.astype(np.int32))))
                 assert(len(batch_idx) == len(np.unique(batch_idx.astype(np.int32))))
-                batch_idx_max = max(batch_idx_max, int(batch_idx.max()))
+                if len(batch_idx):
+                    batch_idx_max = max(batch_idx_max, int(batch_idx.max()))
                 # We are going to assume **consecutive numbering of batch idx** starting from 0
                 # b/c problems arise if one of the targets is missing an entry (eg all voxels predicted ghost,
                 # which means a batch idx is missing from batch_idx for target = input_rescaled)
@@ -267,7 +269,8 @@ def unwrap_scn(data_blob, outputs, batch_id_col, avoid_keys, input_key='input_da
                         print(target, d.shape)
                     batch_id_loc = batch_id_col if d.shape[1] > batch_id_col else -1
                     batch_idx = np.unique(d[:,batch_id_loc])
-                    batch_idx_max = max(batch_idx_max, int(batch_idx.max()))
+                    if len(batch_idx):
+                        batch_idx_max = max(batch_idx_max, int(batch_idx.max()))
                     batch_ctrs.append(int(batch_idx_max+1))
                     try:
                         assert(len(batch_idx) == len(np.unique(batch_idx.astype(np.int32))))


### PR DESCRIPTION
Addresses issue where no node prediction of any type was provided for graphs with no edges (i.e. images with a single object in a graph, e.g. i.e a single particle).