### PR TITLE
Removed unncessary translate call in true interaction vertex.

### DIFF
--- a/analysis/classes/evaluator.py
+++ b/analysis/classes/evaluator.py
@@ -481,7 +481,7 @@ class FullChainEvaluator(FullChainPredictor):
                                 self.data_blob['cluster_label'],
                                 data_idx=entry,
                                 inter_idx=inter_idx)
-                out[inter_idx] = self._translate(vtx, volume)
+                out[inter_idx] = vtx
 
         return out
 


### PR DESCRIPTION
The function get_true_vertices in evaluator.py incorrectly converts from single-volume coordinates to full-volume coordinates despite the true vertex already being in full-volume coordinates. This results in vertices in volume 1 being shifted further in +x outside the volume boundaries. This PR removes this and has been verified by matching neutrinos to their respective interaction true interaction vertex in both volumes.