### PR TITLE
Bug fixes and by-event loading

### DIFF
--- a/analysis/classes/TruthInteraction.py
+++ b/analysis/classes/TruthInteraction.py
@@ -325,7 +325,7 @@ class TruthInteraction(Interaction):
     @cached_property
     def truth_topology(self):
         msg = ""
-        encode = {0: 'g', 1: 'e', 2: 'mu', 3: 'pi', 4: 'p', 5: '?'}
+        encode = {0: 'g', 1: 'e', 2: 'mu', 3: 'pi', 4: 'p', 5: 'k', 6:'?'}
         for i, count in enumerate(self._truth_primary_counts):
             if count > 0:
                 msg += f"{count}{encode[i]}"

--- a/analysis/classes/TruthParticle.py
+++ b/analysis/classes/TruthParticle.py
@@ -127,7 +127,7 @@ class TruthParticle(Particle):
 
         # Load up the 3-momentum (stored in a peculiar way) and the direction
         self.truth_momentum = np.array([getattr(particle, f'p{a}')() for a in ['x', 'y', 'z']])
-        self.truth_start_dir = np.zeros(3)
+        self.truth_start_dir = np.full(3, -np.inf, dtype=np.float32)
         if np.linalg.norm(self.truth_momentum) > 0.:
             self.truth_start_dir = \
                     self.truth_momentum/np.linalg.norm(self.truth_momentum)
@@ -165,7 +165,7 @@ class TruthParticle(Particle):
         # Load up all the 3-vector information
         vec_keys = ['position', 'end_position', 'parent_position',\
                 'ancestor_position', 'first_step', 'last_step',\
-                'start_point', 'end_point']
+                'start_point', 'end_point', 'truth_momentum', 'truth_start_dir']
         
         attribute_keys = scalar_keys + vec_keys
         for attr_name in attribute_keys:

--- a/analysis/classes/TruthParticle.py
+++ b/analysis/classes/TruthParticle.py
@@ -54,6 +54,8 @@ class TruthParticle(Particle):
                  sed_index: np.ndarray = np.empty(0, dtype=np.int64),
                  sed_points: np.ndarray = np.empty((0, 3), dtype=np.float32),
                  sed_depositions_MeV: np.ndarray = np.empty(0, dtype=np.float32),
+                 truth_momentum: np.ndarray = np.full(3, -np.inf, dtype=np.float32),
+                 truth_start_dir: np.ndarray = np.full(3, -np.inf, dtype=np.float32),
                  particle_asis: object = larcv.Particle(),
                  **kwargs):
 
@@ -84,6 +86,10 @@ class TruthParticle(Particle):
 
         # Quantity to be set with the children counting post-processor
         self.children_counts = np.zeros(len(SHAPE_LABELS), dtype=np.int64)
+
+        # Quantities derived from the LArCV particle
+        self.truth_momentum = truth_momentum
+        self.truth_start_dir = truth_start_dir
 
         # Quantities to be set with track range reconstruction post-processor
         self.length_tng  = -1.
@@ -128,7 +134,7 @@ class TruthParticle(Particle):
         # Load up the 3-momentum (stored in a peculiar way) and the direction
         self.truth_momentum = np.array([getattr(particle, f'p{a}')() for a in ['x', 'y', 'z']])
         self.truth_start_dir = np.full(3, -np.inf, dtype=np.float32)
-        if np.linalg.norm(self.truth_momentum) > 0.:
+        if np.linalg.norm(self.truth_momentum):
             self.truth_start_dir = \
                     self.truth_momentum/np.linalg.norm(self.truth_momentum)
 
@@ -165,7 +171,7 @@ class TruthParticle(Particle):
         # Load up all the 3-vector information
         vec_keys = ['position', 'end_position', 'parent_position',\
                 'ancestor_position', 'first_step', 'last_step',\
-                'start_point', 'end_point', 'truth_momentum', 'truth_start_dir']
+                'start_point', 'end_point']
         
         attribute_keys = scalar_keys + vec_keys
         for attr_name in attribute_keys:

--- a/analysis/manager.py
+++ b/analysis/manager.py
@@ -288,7 +288,7 @@ class AnaToolsManager:
         print(f'Took total of {dt:.3f} seconds for one iteration of inference.')
         return data, res
 
-    def forward(self, iteration=None):
+    def forward(self, iteration=None, run=None, event=None):
         '''
         Read one minibatch worth of image from dataset.
 
@@ -297,6 +297,10 @@ class AnaToolsManager:
         iteration : int, optional
             Iteration number, needed for reading entries from
             HDF5 files, by default None.
+        run : int, optional
+            Run number
+        event : int, optional
+            Event number
 
         Returns
         -------
@@ -306,7 +310,10 @@ class AnaToolsManager:
             Result dictionary containing full chain outputs
         '''
         if self.reader_state == 'file':
-            assert iteration is not None
+            assert (iteration is not None) \
+                    ^ (run is not None and event is not None)
+            if iteration is None:
+                iteration = self._data_reader.get_event_index(run, event)
             data, res = self._data_reader.get(iteration, nested=True)
             file_index = self._data_reader.file_index[iteration]
             data['file_index'] = [file_index]

--- a/analysis/post_processing/reconstruction/kinematics.py
+++ b/analysis/post_processing/reconstruction/kinematics.py
@@ -238,6 +238,8 @@ class InteractionTopologyProcessor(PostProcessor):
                     ke = getattr(p, ke_attr)
                     if p.pid > 0 and ke < self.ke_thresholds[p.pid]:
                         p.is_valid = False
+                    else:
+                        p.is_valid = True
 
                 # Update the interaction particle counts
                 ii._update_particle_info()

--- a/mlreco/iotools/readers.py
+++ b/mlreco/iotools/readers.py
@@ -12,7 +12,7 @@ class HDF5Reader:
     More documentation to come.
     '''
     def __init__(self, file_keys, n_entry=-1, n_skip=-1, entry_list=[],
-            skip_entry_list=[], create_run_map=True, to_larcv=False):
+            skip_entry_list=[], create_run_map=False, to_larcv=False):
         '''
         Load up the HDF5 file.
 

--- a/mlreco/iotools/readers.py
+++ b/mlreco/iotools/readers.py
@@ -1,7 +1,9 @@
 import yaml
 import h5py
 import glob
+import warnings
 import numpy as np
+
 
 class HDF5Reader:
     '''
@@ -9,8 +11,8 @@ class HDF5Reader:
 
     More documentation to come.
     '''
-
-    def __init__(self, file_keys, n_entry=-1, n_skip=-1, entry_list=[], skip_entry_list=[], to_larcv=False):
+    def __init__(self, file_keys, n_entry=-1, n_skip=-1, entry_list=[],
+            skip_entry_list=[], create_run_map=True, to_larcv=False):
         '''
         Load up the HDF5 file.
 
@@ -26,6 +28,8 @@ class HDF5Reader:
             Entry IDs to be accessed. If not specified, expose all entries
         skip_entry_list: list(int), optional
             Entry IDs to be skipped
+        create_run_map : bool, default True
+            Initialize a map between [run, event] pairs and entries
         to_larcv : bool, default False
             Convert dictionary of LArCV object properties to LArCV objects
         '''
@@ -35,38 +39,71 @@ class HDF5Reader:
             file_keys = [file_keys]
         for file_key in file_keys:
             file_paths = glob.glob(file_key)
-            assert len(file_paths), f'File key {file_key} yielded no compatible path'
+            assert len(file_paths), \
+                    f'File key {file_key} yielded no compatible path'
             self.file_paths.extend(file_paths)
+
         self.file_paths = sorted(self.file_paths)
 
         # Loop over the input files, build a map from index to file ID
         self.num_entries  = 0
         self.file_index   = []
+        self.run_info     = []
         self.split_groups = None
         self.max_print    = 10
         for i, path in enumerate(self.file_paths):
             with h5py.File(path, 'r') as in_file:
                 # Check that there are events in the file and the storage mode
-                assert 'events' in in_file, 'File does not contain an event tree'
+                assert 'events' in in_file, \
+                        'File does not contain an event tree'
 
                 split_groups = 'data' in in_file and 'result' in in_file
-                assert self.split_groups is None or self.split_groups == split_groups,\
+                assert self.split_groups is None \
+                        or self.split_groups == split_groups, \
                         'Cannot load files with different storing schemes'
                 self.split_groups = split_groups
 
-                self.num_entries += len(in_file['events'])
-                self.file_index.append(i*np.ones(len(in_file['events']), dtype=np.int32))
+                # If requested, register the [run, event] information pair
+                if create_run_map:
+                    source = in_file['data'] if split_groups else in_file
+                    assert 'run_info' in source, \
+                            'Must provide run info to create run map'
+                    run_info = source['run_info']
+                    for r, e in zip(run_info['run'], run_info['event']):
+                        self.run_info.append([r, e])
 
+                # Update the total number of entries
+                num_entries = len(in_file['events'])
+                self.num_entries += num_entries
+                self.file_index.append(i*np.ones(num_entries, dtype=np.int32))
+
+                # Print
                 if i < self.max_print:
                     print('Registered', path)
                 elif i == self.max_print:
                     print('...')
+
         print(f'Registered {len(self.file_paths)} file(s)')
 
+        # Turn file index and run info into np.ndarray, check for duplicates
         self.file_index = np.concatenate(self.file_index)
+        if len(self.run_info):
+            assert len(self.run_info) == self.num_entries
+            self.run_info = np.vstack(self.run_info)
+            has_duplicates = not np.all(np.unique(self.run_info,
+                axis = 0, return_counts=True)[-1] == 1)
+            if has_duplicates:
+                warnings.warn('There are duplicated [run, event] pairs',
+                        RuntimeWarning)
 
         # Build an entry index to access, modify file index accordingly
-        self.entry_index = self.get_entry_list(n_entry, n_skip, entry_list, skip_entry_list)
+        self.entry_index = self.initialize_entry_list(n_entry,
+                n_skip, entry_list, skip_entry_list)
+
+        # If run_info is set, flip it into a map from info to entry
+        self.run_map = None
+        if len(self.run_info):
+            self.run_map = {tuple(v):i for i, v in enumerate(self.run_info)}
 
         # Set whether or not to initialize LArCV objects as such
         self.to_larcv = to_larcv
@@ -135,7 +172,48 @@ class HDF5Reader:
         else:
             return dict(data_blob, **result_blob)
 
-    def get_entry_list(self, n_entry, n_skip, entry_list, skip_entry_list):
+    def get_event(self, run, event, nested=False):
+        '''
+        Returns an entry corresponding to a specific (run, event) pair
+
+        Parameters
+        ----------
+        run : int
+            Run number
+        event : int
+            Event number
+        nested : bool, default `False`
+            If true, nest the output in an array of length 1 (for analysis tools)
+
+        Returns
+        -------
+        data_blob : dict
+            Ditionary of input data products corresponding to one event
+        result_blob : dict
+            Ditionary of result data products corresponding to one event
+        '''
+        return self.get(self.get_event_index(run, event), nested)
+
+    def get_event_index(self, run, event):
+        '''
+        Returns an entry index corresponding to a specific (run, event) pair
+
+        Parameters
+        ----------
+        run : int
+            Run number
+        event : int
+            Event number
+        '''
+        # Get the appropriate entry index
+        assert self.run_map is not None, \
+                'Must build a run map to get entries by [run, event]'
+        assert (run, event) in self.run_map, \
+                f'Could not find (run={run}, event={event}) pair'
+
+        return self.run_map[(run, event)]
+
+    def initialize_entry_list(self, n_entry, n_skip, entry_list, skip_entry_list):
         '''
         Create a list of events that can be accessed by `self.get`
 
@@ -188,6 +266,7 @@ class HDF5Reader:
         if len(entry_list):
             entry_index = entry_index[entry_list]
             self.file_index = self.file_index[entry_list]
+            self.run_info = self.run_info[entry_list]
 
         assert len(entry_index), 'Must at least have one entry to load'
 

--- a/mlreco/iotools/writers.py
+++ b/mlreco/iotools/writers.py
@@ -462,7 +462,7 @@ class HDF5Writer:
                 array = blob[key]
             else:
                 # If an output is a nested scalar, get it for every batch ID
-                # TODO: Must get rid of this option
+                assert len(blob[key]) == self.batch_size or len(blob[key]) == 1
                 array = blob[key][batch_id] \
                         if len(blob[key]) != 1 else blob[key][0]
 

--- a/mlreco/trainval.py
+++ b/mlreco/trainval.py
@@ -222,10 +222,12 @@ class trainval(object):
             self.tspent_sum['io'] += self._watch.time('io')
 
             # Run forward
+            self._model.batch_size = len(input_data['index'][0]) * self._num_volumes
             res = self._forward(input_train, input_loss, iteration=iteration)
 
             # Unwrap output, if requested
             if unwrap:
+                unwrapper.batch_size = len(input_data['index'][0]) * self._num_volumes
                 input_data, res = unwrapper(input_data, res)
             else:
                 if 'index' in input_data:
@@ -270,7 +272,6 @@ class trainval(object):
 
             if not len(self._gpus):
                 train_blob = train_blob[0]
-            #print(not self._net.device_ids)
             result = self._net(train_blob)
 
             if not len(self._gpus):
@@ -488,8 +489,8 @@ class trainval(object):
 
         self._model = model(module_config)
 
-        num_volumes = 1 if not self._boundaries else np.prod([len(b)+1 for b in self._boundaries if b != 'None'])
-        self._model.batch_size = self._minibatch_size * num_volumes
+        self._num_volumes = 1 if not self._boundaries else np.prod([len(b)+1 for b in self._boundaries if b != 'None'])
+        self._model.batch_size = self._minibatch_size * self._num_volumes
 
         self._net = DataParallel(self._model, device_ids=self._gpus)
 


### PR DESCRIPTION
Upgrades/fixes to `HDF5Writer`/`HDF5Reader`:
- Added option to load a specific [run, event] pair using the `HDF5Reader`
- Handle uneven batch size more gracefully: no more fails if `batch_size` changes for the last batch (total number of events not a multiple of the `batch_size`

Bug fixes in `analysis` tools:
- Make sure that the KE cuts are reset before applying new ones in the `adjust_interaction_topology` post-processor
- Load `truth_momentum` and `truth_start_dir` properly from analyzed HDF5 files