### PR TITLE
Small essential bug fixes

### DIFF
--- a/analysis/classes/TruthParticle.py
+++ b/analysis/classes/TruthParticle.py
@@ -114,6 +114,10 @@ class TruthParticle(Particle):
         for k in scalar_keys:
             val = getattr(particle, k)()
             setattr(self, k, val)
+
+        # TODO: Move this to main list once this is in every LArCV file
+        if hasattr(particle, 'gen_id'):
+            setattr(self, 'gen_id', particle.gen_id())
             
         # Exception for particle_id
         self.truth_id = particle.id()
@@ -177,6 +181,10 @@ class TruthParticle(Particle):
             if type(attr) is bytes:
                 attr = attr.decode()
             setattr(self, attr_name, attr)
+
+        # TODO: Move this to main list once this is in every LArCV file
+        if 'gen_id' in particle_dict:
+            setattr(self, 'gen_id', particle_dict['gen_id'])
 
     def merge(self, particle):
         '''

--- a/analysis/post_processing/pmt/flash_matching.py
+++ b/analysis/post_processing/pmt/flash_matching.py
@@ -103,6 +103,6 @@ class FlashMatchingProcessor(PostProcessor):
                 ii.flash_total_pE = float(flash.TotalPE())
                 if hasattr(match, 'hypothesis'):
                     ii.flash_hypothesis = float(np.array(match.hypothesis,
-                        dtype=np.float64).sum())
+                        dtype=np.float32).sum())
 
         return {}, {}

--- a/analysis/post_processing/reconstruction/mcs.py
+++ b/analysis/post_processing/reconstruction/mcs.py
@@ -61,11 +61,13 @@ class MCSEnergyProcessor(PostProcessor):
         assert tracking_mode in ['step', 'step_next', 'bin_pca'], \
                 'The tracking algorithm must provide segment angles'
         self.tracking_mode = tracking_mode
+        self.tracking_kwargs = kwargs
+
+        # Store the MCS parameters
         self.segment_length = segment_length
         self.split_angle = split_angle
         self.res_a = res_a
         self.res_b = res_b
-        self.tracking_kwargs = kwargs
 
     def process(self, data_dict, result_dict):
         '''
@@ -103,6 +105,7 @@ class MCSEnergyProcessor(PostProcessor):
 
                 # Find the angles between successive segments
                 costh = np.sum(dirs[:-1] * dirs[1:], axis = 1)
+                costh = np.clip(costh, -1, 1)
                 theta = np.arccos(costh)
                 if len(theta) < 1:
                     continue

--- a/mlreco/trainval.py
+++ b/mlreco/trainval.py
@@ -227,7 +227,7 @@ class trainval(object):
 
             # Unwrap output, if requested
             if unwrap:
-                unwrapper.batch_size = len(input_data['index'][0]) * self._num_volumes
+                unwrapper.batch_size = len(input_data['index'][0])
                 input_data, res = unwrapper(input_data, res)
             else:
                 if 'index' in input_data:


### PR DESCRIPTION
Fix bug in `mlreco`:
- Multi-volume forward (for ICARUS) was broken at the unwrapping stage. Now fixed.

Small enhancement in `analysis`:
- `TruthParticle` object now load `gen_id` from `larcv.Particle` objects, when available
- Added `np.clip(X, -1, 1)` no cosine of angles in MCS to avoid floating point precision issues