### PR TITLE
Fix bug in csv logging and simplify bayes estimator tool

### DIFF
--- a/analysis/manager.py
+++ b/analysis/manager.py
@@ -274,13 +274,18 @@ class AnaToolsManager:
         # 5. Run scripts, if requested
         start = time.time()
         ana_output = self.run_ana_scripts(data, res, iteration)
-
+        end = time.time()
+        dt = end - start
+        self.logger_dict['ana_scripts'] = dt
+        print(f'Scripts took {dt:.3f} seconds.')
         if len(ana_output) == 0:
             print('No output from analysis scripts.')
+
+        start = time.time()
         self.write(ana_output)
         end = time.time()
         dt = end - start
-        print(f'Scripts took {dt:.3f} seconds.')
+        print(f'Writing to csv took {dt:.3f} seconds.')
         self.logger_dict['write_csv'] = dt
 
         glob_end = time.time()

--- a/analysis/producers/logger.py
+++ b/analysis/producers/logger.py
@@ -463,9 +463,35 @@ class InteractionLogger(AnalysisLogger):
             out = {mapping[pid] : -1 for pid in ptypes}
 
         if ia is not None:
-            if type(ia) is Interaction:
-                for pid in ptypes:
-                    out[mapping[pid]] = ia.primary_counts[pid]
+            # if type(ia) is Interaction:
+            for pid in ptypes:
+                out[mapping[pid]] = ia.primary_counts[pid]
+            # if type(ia) is TruthInteraction:
+            #     for pid in ptypes:
+            #         out[mapping[pid]] = ia.truth_primary_counts[pid]
+            
+        return out
+    
+    
+    @staticmethod
+    @tag('true')
+    def count_truth_primary_particles(ia, ptypes=None):
+        
+        mapping = {
+            0: 'num_truth_primary_photons',
+            1: 'num_truth_primary_electrons',
+            2: 'num_truth_primary_muons',
+            3: 'num_truth_primary_pions',
+            4: 'num_truth_primary_protons'
+        }
+        
+        if ptypes is not None:
+            out = {mapping[pid] : -1 for pid in ptypes}
+        else:
+            ptypes = list(mapping.keys())
+            out = {mapping[pid] : -1 for pid in ptypes}
+
+        if ia is not None:
             if type(ia) is TruthInteraction:
                 for pid in ptypes:
                     out[mapping[pid]] = ia.truth_primary_counts[pid]


### PR DESCRIPTION
Fixed an issue in which the csv logger using MC truth information `TruthInteraction.truth_primary_counts` rather than `TruthInteraction.primary_counts` for counting `TruthInteraction` primary particles. 

In particular, when using `analysis.producers.scripts` to log information to csvs, using the old behavior will have the following effect:
 * When using the `adjust_interaction_topology` post-processor to apply cuts and modify the `TruthInteraction` visible topology, the changes will not be applied to `truth_primary_counts`. This means the adjustment to `TruthInteraction` visible topology from the `adjust_interaction_topology` post-processor will not be saved to the output csvs. 
 
The fix will separate `truth_primary_counts` from `primary_counts` as the following:
```
scripts:
  run_bidirectional_inference:
    logger:
      append: False
      particles:
        ...
      interactions:
        - id
        - size
        - nu_id
        - volume_id
        - count_primary_particles
        - count_truth_primary_particles
```
Here, any changes to the visible topology from applying cuts (`adjust_interaction_topology`) will be applied to `count_primary_particles`, whereas `count_truth_primary_particles` will always log MC truth information. 