### PR TITLE
Crucial bug fixes

### DIFF
--- a/analysis/classes/Particle.py
+++ b/analysis/classes/Particle.py
@@ -150,7 +150,11 @@ class Particle:
 
         # Quantities to be set during post_processing
         self._start_point = start_point
-        self._end_point   = end_point
+        if self.semantic_type == TRACK_SHP:
+            self._end_point = end_point
+        else:
+            self._end_point = np.full(3, -np.inf, dtype=np.float32)
+
         self._start_dir   = start_dir
         self._end_dir     = end_dir
         self.length       = length
@@ -172,8 +176,18 @@ class Particle:
 
     def merge(self, particle):
         '''
-        Merge another particle object into this one
+        Merge another particle object into this one.
+
+        Info
+        ----
+        This scrip can only merge two track objects with well
+        defined start and end points.
         '''
+        # Check that both particles being merged are tracks
+        assert self.semantic_type == TRACK_SHP \
+                and particle.semantic_type == TRACK_SHP, \
+                'Can only merge two track particles'
+
         # Stack the two particle array attributes together
         for attr in ['index', 'depositions']:
             val = np.concatenate([getattr(self, attr), getattr(particle, attr)])
@@ -192,7 +206,7 @@ class Particle:
         max_i, max_j = np.unravel_index(np.argmax(dists), dists.shape)
 
         self.start_point = points_i[max_i]
-        self.end_points = points_j[max_j]
+        self.end_point = points_j[max_j]
         self.start_dir = dirs_i[max_i]
         self.end_dir = dirs_j[max_j]
 

--- a/analysis/post_processing/reconstruction/geometry.py
+++ b/analysis/post_processing/reconstruction/geometry.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from mlreco.utils.globals import TRACK_SHP
 from mlreco.utils.geometry import Geometry
 from mlreco.utils.gnn.cluster import cluster_direction
 
@@ -16,7 +17,7 @@ class DirectionProcessor(PostProcessor):
     result_cap_opt = ['truth_particles']
 
     def __init__(self,
-                 neighborhood_radius = 5,
+                 neighborhood_radius = -1,
                  optimize = True,
                  truth_point_mode = 'points',
                  run_mode = 'both'):
@@ -60,11 +61,11 @@ class DirectionProcessor(PostProcessor):
                     continue
 
                 # Reconstruct directions from either end of the particle
-                # TODO: do not run twice on EM showers (only start point)
                 p.start_dir = cluster_direction(points, p.start_point,
                         self.neighborhood_radius, self.optimize)
-                p.end_dir   = cluster_direction(points, p.end_point,
-                        self.neighborhood_radius, self.optimize)
+                if p.semantic_type == TRACK_SHP:
+                    p.end_dir   = cluster_direction(points, p.end_point,
+                            self.neighborhood_radius, self.optimize)
 
         return {}, {}
 

--- a/mlreco/utils/gnn/cluster.py
+++ b/mlreco/utils/gnn/cluster.py
@@ -624,7 +624,7 @@ def cluster_direction(voxels: nb.float64[:,:],
     # of radius max_dist
     if max_dist > 0:
         dist_mat = nbl.cdist(start.reshape(1,-1), voxels).flatten()
-        voxels = voxels[dist_mat <= max_dist]
+        voxels = voxels[dist_mat <= max(max_dist, np.min(dist_mat))]
 
     # If optimize is set, select the radius by minimizing the transverse spread
     if optimize and len(voxels) > 2:


### PR DESCRIPTION
Simple fix in `cluster_direction` estimator in `mlreco`:
- If `max_dist` is set such that there is no point within it, must minimally select the closest point

A few crucial bug fixes in `analysis`:
- `reconstruct_direction` post-processor uses `optimize=True` by default and `max_dist=-1`
- `end_point` and `end_dir` are set to `(-inf, -inf, -inf)` for all shower objects (undefined)