### PR TITLE
Bayesian estimator handling boundary case

### DIFF
--- a/analysis/producers/scripts/utils.py
+++ b/analysis/producers/scripts/utils.py
@@ -417,5 +417,17 @@ class BayesianBinomialEstimator:
                 min_idx = i
                 min_val = qintv[mode]
         if len(self.q_intvs) == 0:
-            raise AssertionError("No q-credible interval was found.")
+            print("No q-credible interval was found.")
+            index = self.out['index']
+            null_result = {
+                'lb': self.interval[index-1],
+                'lb_index': index-1,
+                'ub': self.interval[index+1],
+                'ub_index': index+1,
+                'length': self.interval[index+1] - self.interval[index-1],
+                'q': self.cdf[index+1] - self.cdf[index-1],
+                'loss': 0.0,
+                'estimator': self.out['eps']
+            }
+            return null_result
         return self.q_intvs[min_idx]


### PR DESCRIPTION
This change concerns the bayesian uncertainty estimator behavior when no q-credible interval may be found using the given floating point resolution.

This could happen when the posterior PDF is so concentrated in the bayes estimate that the prescribed subvdivision of the unit interval [0,1] is too coarse to find the true q-credible interval inside the posterior PDF peak. In this case, the cumulative density function (CDF) transitions from 0 to 1 over a single step. 

Under these circumstances, `compute_q_credible_interval` will output the shortest q-interval than contains *at least* `q` amount of probability that is allowed from the mesh resolution of the unit interval. In short, the probability of finding the true value of purity/efficiency in the returned interval [lb, ub] is at least q. 